### PR TITLE
Removed /network endpoint from cy.visit()

### DIFF
--- a/cypress/integration/Practice/network-requests.spec.js
+++ b/cypress/integration/Practice/network-requests.spec.js
@@ -13,7 +13,7 @@ describe("Network Requests", () => {
       delete req.headers["if-none-match"];
     }).as("posts");
 
-    cy.visit("http://localhost:3000/network");
+    cy.visit("http://localhost:3000");
   });
 
   it("/api/posts returns a status code of 200", () => {


### PR DESCRIPTION
The answers file does not include that endpoint in the before each. I dont know if it was intended but it was causing me errors.