### PR TITLE
Fix practice and answers directory path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ yarn cypress:open
 
 ## Pratice Tests & Answers
 
-The practice tests are located in `cypress/integration/Practice`
+The practice tests are located in `cypress/e2e/Practice`
 
-The answers are located in `cypress/integration/Answers`
+The answers are located in `cypress/e2e/Answers`
 
 ---
 


### PR DESCRIPTION
The paths `cypress/integration/Practice` and `cypress/integration/Answers` don't exist anymore.